### PR TITLE
Limit the coverage report to the closuretree package.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = closuretree


### PR DESCRIPTION
At the moment it's reporting on the whole of Django as well.