### PR TITLE
Add support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
 - 2.7
-- pypy
 env:
 - DJANGO=">=1.6,<1.7"
 - DJANGO=">=1.7,<1.8"
 - DJANGO=">=1.8,<1.9"
 - DJANGO=">=1.9,<1.10"
+- DJANGO=">=1.10,<1.11"
 install:
 - pip install gitversion
 - pip install "Django${DJANGO}"
@@ -25,9 +25,11 @@ matrix:
   - python: 3.4
     env: DJANGO=">=1.9,<1.10"
   - python: 3.5
-    env: DJANGO=">=1.9,<1.10"
+    env: DJANGO=">=1.10,<1.11"
   - python: pypy3
     env: DJANGO=">=1.8,<1.9"
+  - python: pypy
+    env: DJANGO=">=1.9,<1.10"
 deploy:
   provider: pypi
   user: ocadotechnology

--- a/closuretree/models.py
+++ b/closuretree/models.py
@@ -97,7 +97,10 @@ class ClosureModel(with_metaclass(ClosureModelBase, models.Model)):
             id_field_name = "%s_id" % name
         if (
             name.startswith(self._closure_sentinel_attr) and  # It's the right attribute
-            hasattr(self, id_field_name) and  # It's already been set
+            (  # It's already been set
+                (hasattr(self, 'get_deferred_fields') and id_field_name not in self.get_deferred_fields() and hasattr(self, id_field_name)) or  # Django>=1.8
+                (not hasattr(self, 'get_deferred_fields') and hasattr(self, id_field_name))  # Django<1.8
+            ) and
             not self._closure_change_check()  # The old value isn't stored
         ):
             if name.endswith('_id'):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=open('README.rst').read(),
     url='https://github.com/ocadotechnology/django-closuretree/',
     install_requires=[
-        'django >= 1.4',
+        'django >= 1.4, < 1.11',
         'django-autoconfig',
     ],
     tests_require=['django-setuptest >= 0.2'],


### PR DESCRIPTION
There's a new way of handling deferred fields, which the old code didn't pick up on. Add new detection for Django >=1.8
Fixes #32