### PR TITLE
Wrap saving operations in a transaction

### DIFF
--- a/closuretree/tests.py
+++ b/closuretree/tests.py
@@ -24,8 +24,9 @@
 # pylint: disable=
 
 from django import VERSION
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.db import models
+from django.db.utils import IntegrityError
 from closuretree.models import ClosureModel
 import uuid
 
@@ -118,6 +119,54 @@ class BaseTestCase(TestCase):
         self.b.delete()
         self.failUnlessEqual(self.closure_model.objects.count(), 2)
 
+class DirtyParentTestCase(TransactionTestCase):
+
+    normal_model = TC
+    closure_model = TCClosure
+
+    def setUp(self):
+        self.a = self.normal_model.objects.create(name="a")
+        self.b = self.normal_model.objects.create(name="b")
+        self.c = self.normal_model.objects.create(name="c")
+        self.d = self.normal_model.objects.create(name="d")
+
+    def test_selfreferencing_parent(self):
+        """Tests that instances with self-referencing parents are not saved"""
+        self.b.parent2 = self.a
+        self.b.save()
+        self.c.parent2 = self.b
+        self.c.save()
+
+        # this is the prerequisite of this test:
+        # closure model contains 7 rows before we save dirty data
+        self.assertEqual(self.closure_model.objects.count(), 7)
+
+        # dirty data
+        self.b.parent2 = self.b
+        # save dirty data
+        self.assertRaises(IntegrityError, self.b.save)
+
+        # closure model contains the same number of data as before
+        self.assertEqual(self.closure_model.objects.count(), 7)
+
+    def test_parent_referencing_child(self):
+        """Tests instances with circular-referencing parents are not saved"""
+        self.b.parent2 = self.a
+        self.b.save()
+        self.c.parent2 = self.b
+        self.c.save()
+
+        # this is the prerequisite of this test:
+        # closure model contains 7 rows before we save dirty data
+        self.assertEqual(self.closure_model.objects.count(), 7)
+
+        # dirty data
+        self.b.parent2 = self.c
+        # save dirty data
+        self.assertRaises(IntegrityError, self.b.save)
+
+        # closure model contains the same number of data as before
+        self.assertEqual(self.closure_model.objects.count(), 7)
 
 if VERSION >= (1, 8):
     class UUIDTC(ClosureModel):


### PR DESCRIPTION
The current implementation seems to break the closure tree when we try to save an instance with dirty parent value (i.e. referencing self or child). This causes db constraint failure, so I suggest we wrap the saving operation in a transaction to detect and reject dirty data.