### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ django-closuretree
 .. image:: https://coveralls.io/repos/ocadotechnology/django-closuretree/badge.svg
    :target: https://coveralls.io/r/ocadotechnology/django-closuretree
    :alt: Test Coverage
-.. image:: https://pypip.in/v/django-closuretree/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/django-closuretree.svg?style=flat
    :target: https://pypi.python.org/pypi/django-closuretree/
    :alt: Version Badge
-.. image:: https://pypip.in/license/django-closuretree/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/django-closuretree.svg?style=flat
    :target: https://pypi.python.org/pypi/django-closuretree/
    :alt: License Badge
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-closuretree))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-closuretree`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.