### PR TITLE
Support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,14 @@ matrix:
     env: DJANGO=">=1.10,<1.11"
   - python: 3.5
     env: DJANGO=">=1.11,<1.12"
+  - python: 3.6
+    env: DJANGO=">=2.0,<2.1"
   - python: pypy3
     env: DJANGO=">=1.8,<1.9"
   - python: pypy
     env: DJANGO=">=1.9,<1.10"
+  - python: pypy3.5-5.10.1
+    env: DJANGO=">=2.0,<2.1"
 deploy:
   provider: pypi
   user: ocadotechnology

--- a/closuretree/models.py
+++ b/closuretree/models.py
@@ -49,10 +49,12 @@ def create_closure_model(cls):
     model = type('%sClosure' % cls.__name__, (models.Model,), {
         'parent': models.ForeignKey(
             cls.__name__,
+            on_delete=models.CASCADE,
             related_name=cls.closure_parentref()
         ),
         'child': models.ForeignKey(
             cls.__name__,
+            on_delete=models.CASCADE,
             related_name=cls.closure_childref()
         ),
         'depth': models.IntegerField(),

--- a/closuretree/tests.py
+++ b/closuretree/tests.py
@@ -29,16 +29,21 @@ from django.db import models
 from closuretree.models import ClosureModel
 import uuid
 
+class Blah(models.Model):
+    """A test model for foreign keys"""
+    thing = models.CharField(max_length=32)
+
 class TC(ClosureModel):
     """A test model."""
     parent2 = models.ForeignKey(
         "self",
+        on_delete=models.CASCADE,
         related_name="children",
         null=True,
         blank=True
     )
     name = models.CharField(max_length=32)
-    blah = models.ForeignKey("Blah", related_name="tcs", null=True, blank=True)
+    blah = models.ForeignKey("Blah", on_delete=models.CASCADE, related_name="tcs", null=True, blank=True)
 
     class ClosureMeta(object):
         """Closure options."""
@@ -46,10 +51,6 @@ class TC(ClosureModel):
 
     def __unicode__(self):
         return "%s: %s" % (self.pk, self.name)
-
-class Blah(models.Model):
-    """A test model for foreign keys"""
-    thing = models.CharField(max_length=32)
 
 class TCSUB(TC):
     """Testing closure subclasses."""
@@ -125,6 +126,7 @@ if VERSION >= (1, 8):
         primary_key = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
         parent2 = models.ForeignKey(
             "self",
+            on_delete=models.CASCADE,
             related_name="children",
             null=True,
             blank=True,
@@ -340,6 +342,7 @@ class SentinelModel(ClosureModel):
     """A model using a sentinel attribute."""
     location = models.ForeignKey(
         "IntermediateModel",
+        on_delete=models.CASCADE,
         null=True,
         blank=True
     )
@@ -361,6 +364,7 @@ class IntermediateModel(models.Model):
     """
     real_parent = models.ForeignKey(
         'SentinelModel',
+        on_delete=models.CASCADE,
         null=True,
         blank=True,
     )
@@ -410,6 +414,7 @@ class TCNoMeta(ClosureModel):
     """A test model without a ClosureMeta."""
     parent = models.ForeignKey(
         "self",
+        on_delete=models.CASCADE,
         related_name="children",
         null=True,
         blank=True
@@ -437,6 +442,7 @@ class TCAbstract(ClosureModel):
 
     parent = models.ForeignKey(
         "self",
+        on_delete=models.CASCADE,
         related_name="children",
         null=True,
         blank=True

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=open('README.rst').read(),
     url='https://github.com/ocadotechnology/django-closuretree/',
     install_requires=[
-        'django >= 1.4, < 1.12',
+        'django >= 1.4, < 2.1',
         'django-autoconfig',
     ],
     tests_require=['django-setuptest >= 0.2'],


### PR DESCRIPTION
Django 2.0 made the `on_delete` argument of `ForeignKey`s required. I have added this argument (set to `models.CASCADE`, since it think it is the only logical option) to both code and tests. I've also updated `.travis.yml` to include the Django 2.0 environment on Python 3.6 and PyPy3.5v5.10.1.