### PR TITLE
Add gitversion as a required dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         'django >= 1.4, < 1.12',
         'django-autoconfig',
+        'gitversion',
     ],
     tests_require=['django-setuptest >= 0.2'],
     test_suite='setuptest.setuptest.SetupTestSuite',


### PR DESCRIPTION
Cannot install this via Pipenv or pip because gitversion is a missing required dependency. Setup.py imports `from closuretree.version import __VERSION__` which requires gitversion to be installed.