### PR TITLE
Fix: __unicode__ must return unicode

### DIFF
--- a/closuretree/models.py
+++ b/closuretree/models.py
@@ -37,7 +37,7 @@ def _closure_model_unicode(self):
     """__unicode__ implementation for the dynamically created
         <Model>Closure model.
     """
-    return "Closure from %s to %s" % (self.parent, self.child)
+    return u"Closure from %s to %s" % (self.parent, self.child)
 
 def create_closure_model(cls):
     """Creates a <Model>Closure model in the same module as the model."""


### PR DESCRIPTION
Because if `str(self.parent)` returns something like `\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82` and you try to `print(ModelClosure)`, you will get `UnicodeEncodeError`

I see this error in Django Admin interface on delete confirmation page when I try to delete `User` which has linked `Comments` which have `CommentClosure` instances saved in database. And django admin trying to show string representation of all objects and fails.

Reference:
- https://docs.python.org/2.7/library/stdtypes.html#string-formatting (note 6)
- https://docs.python.org/2/library/functions.html#unicode
